### PR TITLE
Check/Pin action.yml files in repos

### DIFF
--- a/workflow_shas/commands/check.py
+++ b/workflow_shas/commands/check.py
@@ -336,7 +336,10 @@ def generate_tracking_body(org: str, results: list[dict]) -> str:
         table_rows = []
         for r in sorted(pinned, key=lambda x: x["name"]):
             repo_link = f"[{r['name']}](https://github.com/{org}/{r['name']})"
-            wf_list = ", ".join(f"`{wf}`" for wf in sorted(r["workflow_files"]))
+            wf_list = ", ".join(
+                [f"`{wf}`" for wf in sorted(r["workflow_files"])]
+                + [f"`{af}`" for af in sorted(r.get("action_files", []))]
+            )
             table_rows.append([repo_link, enforcement_label(r), wf_list])
         lines.extend(
             format_table(["Repository", "Enforced", "Workflow Files"], table_rows)

--- a/workflow_shas/commands/pin.py
+++ b/workflow_shas/commands/pin.py
@@ -279,66 +279,90 @@ def resolve_full_version_tag(repo_slug: str, sha: str, original_ref: str) -> str
     return candidates[0]
 
 
+def _pin_file(
+    wf_file: Path,
+    cache: dict[tuple[str, str], tuple[str, str] | None],
+) -> bool:
+    """Pin action refs in a single file. Returns True if the file was modified."""
+    content = wf_file.read_text()
+    new_content = content
+
+    for match in USES_PATTERN.finditer(content):
+        prefix = match.group(1)
+        action = match.group(2)
+        ref = match.group(3)
+
+        if " " in ref:
+            ref = ref.split()[0]
+
+        if action.startswith("./") or action.startswith("docker://"):
+            continue
+
+        if SHA_PATTERN.match(ref):
+            continue
+
+        repo_slug = _repo_slug(action)
+        cache_key = (repo_slug, ref)
+
+        if cache_key not in cache:
+            sha = resolve_ref_to_sha(repo_slug, ref)
+            if sha is None:
+                print(f"    WARNING: could not resolve {action}@{ref}")
+                cache[cache_key] = None
+            else:
+                version_tag = resolve_full_version_tag(repo_slug, sha, ref)
+                cache[cache_key] = (sha, version_tag)
+
+        resolved = cache[cache_key]
+        if resolved is None:
+            continue
+
+        sha, version_tag = resolved
+        old_text = f"{prefix}{action}@{match.group(3)}"
+        new_text = f"{prefix}{action}@{sha}  # {version_tag}"
+        new_content = new_content.replace(old_text, new_text, 1)
+
+        if version_tag != ref:
+            print(
+                f"    {wf_file.name}: {action}@{ref} -> @{sha[:12]}... # {version_tag}"
+            )
+        else:
+            print(f"    {wf_file.name}: {action}@{ref} -> @{sha[:12]}... # {ref}")
+
+    if new_content != content:
+        wf_file.write_text(new_content)
+        return True
+    return False
+
+
 def pin_actions(work_dir: Path) -> bool:
     """Rewrite all action and reusable workflow refs to SHA pins.
 
+    Processes .github/workflows/*.yml and any action.yml/action.yaml
+    files found anywhere in the repo.
+
     Returns True if any files were modified.
     """
-    workflows_dir = work_dir / ".github" / "workflows"
-    if not workflows_dir.is_dir():
-        print("    No .github/workflows directory found")
-        return False
-
     cache: dict[tuple[str, str], tuple[str, str] | None] = {}
 
-    for wf_file in sorted(workflows_dir.glob("*.y*ml")):
-        content = wf_file.read_text()
-        new_content = content
+    files_to_pin: list[Path] = []
 
-        for match in USES_PATTERN.finditer(content):
-            prefix = match.group(1)
-            action = match.group(2)
-            ref = match.group(3)
+    # Workflow files
+    workflows_dir = work_dir / ".github" / "workflows"
+    if workflows_dir.is_dir():
+        files_to_pin.extend(sorted(workflows_dir.glob("*.y*ml")))
 
-            if " " in ref:
-                ref = ref.split()[0]
+    # Action definition files anywhere in the repo
+    for action_file in sorted(work_dir.rglob("action.y*ml")):
+        if action_file.name in ("action.yml", "action.yaml"):
+            files_to_pin.append(action_file)
 
-            if action.startswith("./") or action.startswith("docker://"):
-                continue
+    if not files_to_pin:
+        print("    No workflow or action files found")
+        return False
 
-            if SHA_PATTERN.match(ref):
-                continue
-
-            repo_slug = _repo_slug(action)
-            cache_key = (repo_slug, ref)
-
-            if cache_key not in cache:
-                sha = resolve_ref_to_sha(repo_slug, ref)
-                if sha is None:
-                    print(f"    WARNING: could not resolve {action}@{ref}")
-                    cache[cache_key] = None
-                else:
-                    version_tag = resolve_full_version_tag(repo_slug, sha, ref)
-                    cache[cache_key] = (sha, version_tag)
-
-            resolved = cache[cache_key]
-            if resolved is None:
-                continue
-
-            sha, version_tag = resolved
-            old_text = f"{prefix}{action}@{match.group(3)}"
-            new_text = f"{prefix}{action}@{sha}  # {version_tag}"
-            new_content = new_content.replace(old_text, new_text, 1)
-
-            if version_tag != ref:
-                print(
-                    f"    {wf_file.name}: {action}@{ref} -> @{sha[:12]}... # {version_tag}"
-                )
-            else:
-                print(f"    {wf_file.name}: {action}@{ref} -> @{sha[:12]}... # {ref}")
-
-        if new_content != content:
-            wf_file.write_text(new_content)
+    for f in files_to_pin:
+        _pin_file(f, cache)
 
     # Check via git diff whether anything actually changed on disk
     result = run_cmd("git", "diff", "--quiet", cwd=work_dir, check=False)
@@ -354,6 +378,11 @@ def has_changes(work_dir: Path) -> bool:
 def commit_changes(work_dir: Path) -> None:
     """Stage and commit the pinning changes."""
     run_cmd("git", "add", ".github/workflows/", cwd=work_dir)
+    # Stage any action.yml/action.yaml files anywhere in the repo
+    for action_file in work_dir.rglob("action.y*ml"):
+        if action_file.name in ("action.yml", "action.yaml"):
+            rel = action_file.relative_to(work_dir)
+            run_cmd("git", "add", str(rel), cwd=work_dir)
 
     result = run_cmd("git", "diff", "--cached", "--quiet", cwd=work_dir, check=False)
     if result.returncode == 0:

--- a/workflow_shas/scan.py
+++ b/workflow_shas/scan.py
@@ -54,6 +54,27 @@ def get_workflow_files(org: str, repo_name: str) -> list[str]:
         return []
 
 
+def get_action_files(org: str, repo_name: str) -> list[str]:
+    """Find all action.yml / action.yaml files anywhere in the repo."""
+    try:
+        output = run_gh(
+            "api",
+            f"repos/{org}/{repo_name}/git/trees/HEAD?recursive=1",
+            "-q",
+            '.tree[] | select(.type == "blob") | .path',
+            "--paginate",
+        )
+    except RuntimeError:
+        return []
+
+    return [
+        p.strip()
+        for p in output.strip().split("\n")
+        if p.strip().endswith(("/action.yml", "/action.yaml"))
+        or p.strip() in ("action.yml", "action.yaml")
+    ]
+
+
 def get_file_content(org: str, repo_name: str, path: str) -> str:
     """Get raw file content from a repo (base64-decoded)."""
     try:
@@ -96,12 +117,14 @@ def check_repo(org: str, repo_name: str) -> dict:
     """Check a single repo for SHA pinning status.
 
     Returns a dict with keys: ``name``, ``has_workflows``, ``all_pinned``,
-    ``sha_pinning_required``, ``sha_pinned``, ``not_pinned``, ``workflow_files``.
+    ``sha_pinning_required``, ``sha_pinned``, ``not_pinned``,
+    ``workflow_files``, ``action_files``.
     """
     sha_pinning_required = get_sha_pinning_required(org, repo_name)
     workflow_files = get_workflow_files(org, repo_name)
+    action_files = get_action_files(org, repo_name)
 
-    if not workflow_files:
+    if not workflow_files and not action_files:
         return {
             "name": repo_name,
             "has_workflows": False,
@@ -110,6 +133,7 @@ def check_repo(org: str, repo_name: str) -> dict:
             "sha_pinned": [],
             "not_pinned": [],
             "workflow_files": [],
+            "action_files": [],
         }
 
     all_sha_pinned: list[str] = []
@@ -118,6 +142,14 @@ def check_repo(org: str, repo_name: str) -> dict:
     for wf in workflow_files:
         path = f".github/workflows/{wf}"
         content = get_file_content(org, repo_name, path)
+        if not content:
+            continue
+        result = analyze_workflow(content)
+        all_sha_pinned.extend(result["sha_pinned"])
+        all_not_pinned.extend(result["not_pinned"])
+
+    for af in action_files:
+        content = get_file_content(org, repo_name, af)
         if not content:
             continue
         result = analyze_workflow(content)
@@ -135,4 +167,5 @@ def check_repo(org: str, repo_name: str) -> dict:
         "sha_pinned": sorted(set(all_sha_pinned)),
         "not_pinned": sorted(set(all_not_pinned)),
         "workflow_files": workflow_files,
+        "action_files": action_files,
     }


### PR DESCRIPTION
Also now check and pin `action.yml` files inside repos.

This was noticed in https://github.com/esphome/data.esphome.io which has internal composite actions that were not pinned.